### PR TITLE
fxing minor case of "don't repeat yourself"

### DIFF
--- a/nailgun/nailgun/objects/node.py
+++ b/nailgun/nailgun/objects/node.py
@@ -491,9 +491,7 @@ class Node(NailgunObject):
         #(dshulyak) change this verification to NODE_STATUSES.deploying
         # after we will reuse ips from dhcp range
         netmanager = Cluster.get_network_manager()
-        admin_ng = netmanager.get_admin_network_group()
-        if data.get('ip') and not netmanager.is_same_network(data['ip'],
-                                                             admin_ng.cidr):
+        if data.get('ip') and not netmanager.is_ip_belongs_to_admin_subnet(data['ip']):
             logger.debug(
                 'Corrupted network data %s, skipping update',
                 instance.id)


### PR DESCRIPTION
I think the original purpose of the replaced code was to ensure that the IP address of the node is in the admin subnet. It would therefore make sense IMHO to use the existing function is_ip_belongs_to_admin_subnet as we may decide later that is_ip_belongs_to_admin_subnet may use other criteria than just checking if the IP is within the range of one given CIDR. Think multiple disjunct admin network segments for example or think IKv6 (see also https://blueprints.launchpad.net/fuel/+spec/add-ipv6-support-to-fuel; not that there is too much action yet on that one ;-) ).
