### PR TITLE
Enable vCenter with NSX deployment

### DIFF
--- a/nailgun/nailgun/fixtures/openstack.yaml
+++ b/nailgun/nailgun/fixtures/openstack.yaml
@@ -338,8 +338,6 @@
               - data: "vcenter"
                 label: "vCenter"
                 description: "Choose this type of hypervisor if you run OpenStack in a vCenter environment."
-                restrictions:
-                  - "settings:common.libvirt_type.value != 'vcenter' or cluster:net_provider == 'neutron'"
             label: "Hypervisor type"
             weight: 30
             type: "radio"
@@ -377,9 +375,6 @@
           metadata:
             weight: 50
             label: "Public network assignment"
-            restrictions:
-              - condition: "cluster:net_provider != 'neutron'"
-                action: "hide"
           assign_to_all_nodes:
             value: false
             label: "Assign public network to all nodes"
@@ -991,8 +986,6 @@
                 - "cluster:net_segment_type": "vlan"
             - data: "neutron-nsx"
               label: "dialog.create_cluster_wizard.network.neutr_nsx"
-              restrictions:
-                - "Compute.hypervisor == 'vcenter'": "dialog.create_cluster_wizard.network.hypervisor_alert"
               bind:
                 - "cluster:net_provider": "neutron"
                 - "cluster:net_l23_provider": "nsx"


### PR DESCRIPTION
Allow deployment vCenter with NSX as networking option.

In progress. Don't merge now.
