### PR TITLE
PROD-6530 Fuel Nailgun: Noop run support

### DIFF
--- a/nailgun/nailgun/api/v1/handlers/cluster.py
+++ b/nailgun/nailgun/api/v1/handlers/cluster.py
@@ -121,12 +121,13 @@ class ClusterChangesHandler(DeferredTaskHandler):
 
     @classmethod
     def get_options(cls):
-        data = web.input(graph_type=None, dry_run="0")
+        data = web.input(graph_type=None, dry_run="0", noop_run="0")
 
         return {
             'graph_type': data.graph_type or None,
             'force': False,
             'dry_run': utils.parse_bool(data.dry_run),
+            'noop_run': utils.parse_bool(data.noop_run),
         }
 
 

--- a/nailgun/nailgun/api/v1/handlers/deployment_history.py
+++ b/nailgun/nailgun/api/v1/handlers/deployment_history.py
@@ -43,6 +43,8 @@ class DeploymentHistoryCollectionHandler(base.CollectionHandler):
         nodes_ids = self.get_param_as_set('nodes_ids')
         statuses = self.get_param_as_set('statuses')
         tasks_names = self.get_param_as_set('tasks_names')
+        include_summary = utils.parse_bool(
+            web.input(include_summary="0").include_summary)
         try:
             self.validator.validate_query(nodes_ids=nodes_ids,
                                           statuses=statuses,
@@ -54,4 +56,5 @@ class DeploymentHistoryCollectionHandler(base.CollectionHandler):
         return self.collection.get_history(transaction=transaction,
                                            nodes_ids=nodes_ids,
                                            statuses=statuses,
-                                           tasks_names=tasks_names)
+                                           tasks_names=tasks_names,
+                                           include_summary=include_summary)

--- a/nailgun/nailgun/db/migration/alembic_migrations/versions/fuel_10_0.py
+++ b/nailgun/nailgun/db/migration/alembic_migrations/versions/fuel_10_0.py
@@ -38,6 +38,8 @@ def upgrade():
     upgrade_plugin_with_nics_and_nodes_attributes()
     upgrade_node_deployment_info()
     upgrade_release_required_component_types()
+    upgrade_noop_run()
+    upgrade_deployment_history_summary()
 
 
 def downgrade():
@@ -45,6 +47,8 @@ def downgrade():
     downgrade_node_deployment_info()
     downgrade_plugin_with_nics_and_nodes_attributes()
     downgrade_plugin_links_constraints()
+    downgrade_noop_run()
+    downgrade_deployment_history_summary()
 
 
 def upgrade_plugin_links_constraints():
@@ -246,6 +250,30 @@ def upgrade_release_required_component_types():
     )
 
 
+def upgrade_noop_run():
+    op.add_column(
+        'tasks',
+        sa.Column(
+            'noop_run',
+            sa.Boolean,
+            nullable=False,
+            default=False,
+            server_default="false"
+        )
+    )
+
+
+def upgrade_deployment_history_summary():
+    op.add_column(
+        'deployment_history',
+        sa.Column(
+            'summary',
+            fields.JSON(),
+            nullable=False,
+            server_default='{}'
+        )
+    )
+
 def downgrade_plugin_with_nics_and_nodes_attributes():
     op.drop_table('node_cluster_plugins')
     op.drop_table('node_bond_interface_cluster_plugins')
@@ -305,3 +333,11 @@ def downgrade_node_deployment_info():
 
 def downgrade_release_required_component_types():
     op.drop_column('releases', 'required_component_types')
+
+
+def downgrade_noop_run():
+    op.drop_column('tasks', 'noop_run')
+
+
+def downgrade_deployment_history_summary():
+    op.drop_column('deployment_history', 'summary')

--- a/nailgun/nailgun/db/sqlalchemy/models/deployment_history.py
+++ b/nailgun/nailgun/db/sqlalchemy/models/deployment_history.py
@@ -17,6 +17,7 @@
 import sqlalchemy as sa
 
 from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import deferred
 
 from nailgun import consts
 
@@ -56,3 +57,5 @@ class DeploymentHistory(Base):
 
     custom = sa.Column(MutableDict.as_mutable(JSON), default={},
                        server_default='{}', nullable=False)
+    summary = deferred(sa.Column(MutableDict.as_mutable(JSON), default={},
+                       server_default='{}', nullable=True))

--- a/nailgun/nailgun/db/sqlalchemy/models/task.py
+++ b/nailgun/nailgun/db/sqlalchemy/models/task.py
@@ -16,6 +16,7 @@
 
 import uuid
 
+from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import DateTime
 from sqlalchemy import Enum
@@ -82,6 +83,8 @@ class Task(Base):
                                        nullable=True))
     network_settings = deferred(Column(MutableDict.as_mutable(JSON),
                                        nullable=True))
+    noop_run = Column(Boolean, default=False, server_default="0",
+                      nullable=False)
 
     tasks_snapshot = deferred(Column(MutableList.as_mutable(JSON),
                                      nullable=True))

--- a/nailgun/nailgun/objects/deployment_history.py
+++ b/nailgun/nailgun/objects/deployment_history.py
@@ -38,7 +38,7 @@ class DeploymentHistory(NailgunObject):
 
     @classmethod
     def update_if_exist(cls, task_id, node_id, deployment_graph_task_name,
-                        status, custom):
+                        status, custom, summary):
         deployment_history = cls.find_history(task_id, node_id,
                                               deployment_graph_task_name)
 
@@ -49,6 +49,8 @@ class DeploymentHistory(NailgunObject):
             return
 
         getattr(cls, 'to_{0}'.format(status))(deployment_history)
+
+        deployment_history.summary = summary
 
     @classmethod
     def find_history(cls, task_id, node_id, deployment_graph_task_name):
@@ -137,7 +139,7 @@ class DeploymentHistoryCollection(NailgunCollection):
 
     @classmethod
     def get_history(cls, transaction, nodes_ids=None, statuses=None,
-                    tasks_names=None):
+                    tasks_names=None, include_summary=False):
         """Get deployment tasks history.
 
         :param transaction: task SQLAlchemy object
@@ -197,6 +199,9 @@ class DeploymentHistoryCollection(NailgunCollection):
             history.append(record)
             # remove ambiguous field
             record['task_name'] = record.pop('deployment_graph_task_name')
+
+            if 'summary' in record and not include_summary:
+                record.pop('summary')
 
             if task_parameters_by_name:
                 try:

--- a/nailgun/nailgun/rpc/receiver.py
+++ b/nailgun/nailgun/rpc/receiver.py
@@ -278,7 +278,7 @@ class NailgunReceiver(object):
         task = objects.Task.get_by_uuid(task_uuid)
         # Dry run deployments should not actually lead to update of
         # nodes' statuses
-        if task.name != consts.TASK_NAMES.dry_run_deployment:
+        if task.name != consts.TASK_NAMES.dry_run_deployment and not task.noop_run:
 
             # First of all, let's update nodes in database
             for node_db in db_nodes:
@@ -329,7 +329,8 @@ class NailgunReceiver(object):
                     node['uid'],
                     node['deployment_graph_task_name'],
                     node['task_status'],
-                    node.get('custom')
+                    node.get('custom'),
+                    node.get('summary'),
                 )
         db().flush()
 

--- a/nailgun/nailgun/task/manager.py
+++ b/nailgun/nailgun/task/manager.py
@@ -234,7 +234,7 @@ class ApplyChangesTaskManager(BaseDeploymentTaskManager, DeploymentCheckMixin):
         db().flush()
 
     def execute(self, nodes_to_provision_deploy=None, deployment_tasks=None,
-                force=False, graph_type=None, **kwargs):
+                force=False, graph_type=None, noop_run=False, **kwargs):
         logger.info(
             u"Trying to start deployment at cluster '{0}'".format(
                 self.cluster.name or self.cluster.id
@@ -245,7 +245,7 @@ class ApplyChangesTaskManager(BaseDeploymentTaskManager, DeploymentCheckMixin):
         self._remove_obsolete_tasks()
 
         supertask = Task(name=self.deployment_type, cluster=self.cluster,
-                         status=consts.TASK_STATUSES.pending)
+                         status=consts.TASK_STATUSES.pending, noop_run=noop_run)
         db().add(supertask)
 
         nodes_to_delete = TaskHelper.nodes_to_delete(self.cluster)
@@ -279,6 +279,7 @@ class ApplyChangesTaskManager(BaseDeploymentTaskManager, DeploymentCheckMixin):
             force=force,
             graph_type=graph_type,
             current_cluster_status=current_cluster_status,
+            noop_run=noop_run,
             **kwargs
         )
 

--- a/nailgun/nailgun/task/task.py
+++ b/nailgun/nailgun/task/task.py
@@ -487,7 +487,8 @@ class ClusterTransaction(DeploymentTask):
 
     @classmethod
     def task_deploy(cls, transaction, tasks, nodes, force=False,
-                    selected_task_ids=None, dry_run=False, **kwargs):
+                    selected_task_ids=None, dry_run=False, noop_run=False,
+                    **kwargs):
         logger.info("The cluster transaction is initiated.")
         logger.info("cluster serialization is started.")
         # we should update information for all nodes except deleted
@@ -540,6 +541,7 @@ class ClusterTransaction(DeploymentTask):
             "tasks_graph": graph,
             "tasks_metadata": metadata,
             "dry_run": dry_run,
+            "noop_run": noop_run,
         }
 
 

--- a/nailgun/nailgun/test/unit/test_downgrade_fuel_10_0.py
+++ b/nailgun/nailgun/test/unit/test_downgrade_fuel_10_0.py
@@ -109,3 +109,17 @@ class TestRequiredComponentTypesField(base.BaseAlembicMigrationTest):
     def test_downgrade_release_required_component_types(self):
         releases_table = self.meta.tables['releases']
         self.assertNotIn('required_component_types', releases_table.c)
+
+
+class TestTasksNoopRunField(base.BaseAlembicMigrationTest):
+
+    def test_downgrade_tasks_noop(self):
+        tasks = self.meta.tables['tasks']
+        self.assertNotIn('noop_run', tasks.c)
+
+
+class TestDeploymentHistorySummaryField(base.BaseAlembicMigrationTest):
+
+    def test_downgrade_tasks_noop(self):
+        deployment_history = self.meta.tables['deployment_history']
+        self.assertNotIn('summary', deployment_history.c)

--- a/nailgun/nailgun/test/unit/test_migration_fuel_10_0.py
+++ b/nailgun/nailgun/test/unit/test_migration_fuel_10_0.py
@@ -374,6 +374,19 @@ def prepare():
             }
         ]
     )
+    result = db.execute(
+        meta.tables['deployment_history'].insert(),
+        [
+            {
+                'uuid': 'fake_uuid_0',
+                'deployment_graph_task_name': 'fake',
+                'node_id': 'fake_node_id',
+                'task_id': 'fake_task_uuid_0',
+                'status': 'pending',
+                'summary': jsonutils.dumps({'fake': 'fake'}),
+            }
+        ]
+    )
     TestRequiredComponentTypesField.prepare(meta)
     db.commit()
 


### PR DESCRIPTION
Task model is extended with `noop_run` boolean column;
Introdicing and passing down the `noop_run` param from API to
execution manager;
Execution manager supports `noop_run` argument,
and uses it for creating astute message;
DeploymentHistory model is extended with `summary` JSON column;
The summary column should be returned only if some
`include_summary=1` query string is passed to API;
